### PR TITLE
Add static tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
-.editorconfig  export-ignore
-.gitattributes export-ignore
-.gitignore     export-ignore
+.editorconfig          export-ignore
+.gitattributes         export-ignore
+/.github/              export-ignore
+.gitignore             export-ignore
+.php-cs-fixer.dist.php export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist     export-ignore
+/Makefile              export-ignore
+/vendor-bin/           export-ignore

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,73 @@
+name: Static analysis
+
+on:
+  push:
+    branches:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Download dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Download PHPStan
+        run: composer bin phpstan update --no-interaction --no-progress
+
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan analyze --no-progress
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Download dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Download PHP CS Fixer
+        run: composer bin php-cs-fixer update --no-interaction --no-progress
+
+      - name: Execute PHP CS Fixer
+        run: vendor/bin/php-cs-fixer fix --diff --dry-run
+
+  composer-normalize:
+    name: Composer Normalize
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Execute Composer Normalize
+        run: make static-composer-normalize-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.php-cs-fixer.php
+.php-cs-fixer.cache
 composer.lock
 vendor/
+/phpstan.neon
 /phpunit.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,29 @@
+<?php
+
+$config = (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PHP71Migration:risky' => true,
+        '@PHPUnit75Migration:risky' => true,
+        '@PSR12:risky' => true,
+        '@Symfony' => true,
+        'declare_strict_types' => false,
+        'global_namespace_import' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+        ],
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => false,
+        'single_line_throw' => false,
+        'void_return' => false,
+        'yoda_style' => false,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__.'/src')
+            ->name('*.php')
+    )
+;
+
+return $config;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+static: static-phpstan static-codestyle-check static-composer-normalize-check
+
+static-phpstan:
+	composer install
+	composer bin phpstan update
+	vendor/bin/phpstan analyze $(PHPSTAN_PARAMS)
+
+static-phpstan-update-baseline:
+	composer install
+	composer bin phpstan update
+	$(MAKE) static-phpstan PHPSTAN_PARAMS="--generate-baseline"
+
+static-codestyle-fix:
+	composer install
+	composer bin php-cs-fixer update
+	vendor/bin/php-cs-fixer fix --diff $(CS_PARAMS)
+
+static-codestyle-check:
+	$(MAKE) static-codestyle-fix CS_PARAMS="--dry-run"
+
+static-composer-normalize-fix:
+	composer install
+	composer bin composer-normalize update
+	composer bin composer-normalize normalize --diff $(COMPOSER_NORMALIZE_PARAMS) ../../composer.json
+
+static-composer-normalize-check:
+	$(MAKE) static-composer-normalize-fix COMPOSER_NORMALIZE_PARAMS="--dry-run"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "guzzlehttp/test-server",
     "description": "Node.js server and PHP controller",
-    "keywords": [],
     "license": "MIT",
     "authors": [
         {
@@ -25,13 +24,25 @@
         "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "^2.8"
     },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
+    "require-dev": {
+        "bamarni/composer-bin-plugin": "^1.8.2"
     },
     "autoload": {
         "psr-4": {
             "GuzzleHttp\\Server\\": "src/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        },
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": true,
+            "forward-command": false
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors: []

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/Server.php
+++ b/src/Server.php
@@ -26,7 +26,7 @@ use Psr\Http\Message\ResponseInterface;
 class Server
 {
     /**
-     * @var Client
+     * @var Client|null
      */
     private static $client;
     /**
@@ -62,7 +62,7 @@ class Server
     {
         $data = [];
         foreach ((array) $responses as $response) {
-            if (!($response instanceof ResponseInterface)) {
+            if (!$response instanceof ResponseInterface) {
                 throw new InvalidArgumentException('Invalid response given.');
             }
             $headers = \array_map(static function ($h) {
@@ -70,15 +70,15 @@ class Server
             }, $response->getHeaders());
 
             $data[] = [
-                'status'  => (string) $response->getStatusCode(),
-                'reason'  => $response->getReasonPhrase(),
+                'status' => (string) $response->getStatusCode(),
+                'reason' => $response->getReasonPhrase(),
                 'headers' => $headers,
-                'body'    => \base64_encode((string) $response->getBody())
+                'body' => \base64_encode((string) $response->getBody()),
             ];
         }
 
         self::getClient()->request('PUT', 'guzzle-server/responses', [
-            'json' => $data
+            'json' => $data,
         ]);
     }
 
@@ -96,15 +96,15 @@ class Server
     {
         $data = [
             [
-                'status'  => (string) $statusCode,
-                'reason'  => $reasonPhrase,
+                'status' => (string) $statusCode,
+                'reason' => $reasonPhrase,
                 'headers' => $headers,
-                'body'    => \base64_encode((string) $body)
-            ]
+                'body' => \base64_encode((string) $body),
+            ],
         ];
 
         self::getClient()->request('PUT', 'guzzle-server/responses', [
-            'json' => $data
+            'json' => $data,
         ]);
     }
 
@@ -133,7 +133,7 @@ class Server
             static function ($message) {
                 $uri = $message['uri'];
                 if (isset($message['query_string'])) {
-                    $uri .= '?' . $message['query_string'];
+                    $uri .= '?'.$message['query_string'];
                 }
                 $response = new Psr7\Request(
                     $message['http_method'],
@@ -142,6 +142,7 @@ class Server
                     $message['body'],
                     $message['version']
                 );
+
                 return $response->withUri(
                     $response->getUri()
                         ->withScheme('http')
@@ -197,11 +198,11 @@ class Server
                 throw new InvalidArgumentException('Invalid node.js server port');
             }
 
-            $script = __DIR__ . \DIRECTORY_SEPARATOR . 'server.js';
-            $logFile = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'server.log';
+            $script = __DIR__.\DIRECTORY_SEPARATOR.'server.js';
+            $logFile = \sys_get_temp_dir().\DIRECTORY_SEPARATOR.'server.log';
 
             $process = \proc_open(
-                'node ' . \escapeshellarg($script) . ' ' . $port,
+                'node '.\escapeshellarg($script).' '.$port,
                 [
                     0 => ['pipe', 'r'],
                     1 => ['file', $logFile, 'a'],
@@ -238,8 +239,9 @@ class Server
         try {
             self::getClient()->request('GET', 'guzzle-server/perf', [
                 'connect_timeout' => 5,
-                'timeout'         => 5
+                'timeout' => 5,
             ]);
+
             return true;
         } catch (\Exception $e) {
             return false;
@@ -248,10 +250,10 @@ class Server
 
     private static function getClient()
     {
-        if (!self::$client) {
+        if (null === self::$client) {
             self::$client = new Client([
                 'base_uri' => self::$url,
-                'sync'     => true,
+                'sync' => true,
             ]);
         }
 

--- a/vendor-bin/composer-normalize/composer.json
+++ b/vendor-bin/composer-normalize/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "ergebnis/composer-normalize": "2.52.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        },
+        "preferred-install": "dist"
+    }
+}

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "php": "^7.4",
+        "friendsofphp/php-cs-fixer": "^3.95.2"
+    },
+    "config": {
+        "preferred-install": "dist"
+    }
+}

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.4",
-        "friendsofphp/php-cs-fixer": "^3.95.2"
+        "friendsofphp/php-cs-fixer": "3.95.2"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php": "^8.2",
+        "phpstan/phpstan": "2.1.55",
+        "phpstan/phpstan-deprecation-rules": "2.0.4"
+    },
+    "config": {
+        "preferred-install": "dist"
+    }
+}


### PR DESCRIPTION
Adds the shared static tooling setup to this repository. The static workflow now runs PHPStan, PHP-CS-Fixer, and Composer Normalize through Makefile targets, with the same tool versions and read-only workflow permissions used across the Guzzle repos.