### PR TITLE
Run static analysis on PHP 7.4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '7.4'
           coverage: none
 
       - name: Download dependencies

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,2 @@
 parameters:
-    ignoreErrors: []
+	ignoreErrors: []

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.2",
+        "php": "^7.4",
         "phpstan/phpstan": "2.1.55",
         "phpstan/phpstan-deprecation-rules": "2.0.4"
     },


### PR DESCRIPTION
Runs the PHPStan static job on PHP 7.4 and lowers the isolated PHPStan tool manifest PHP constraint to ^7.4 so all static tooling runs consistently on PHP 7.4.