### PR TITLE
Require next major Guzzle dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "guzzlehttp/guzzle": "^7.10",
-        "guzzlehttp/psr7": "^2.8"
+        "guzzlehttp/guzzle": "^8.0@dev",
+        "guzzlehttp/psr7": "^3.0@dev"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^8.0@dev",
         "guzzlehttp/psr7": "^3.0@dev"
     },


### PR DESCRIPTION
Summary: Updates the 1.0 branch to require next-major development lines for guzzlehttp/guzzle and guzzlehttp/psr7. Verification: git diff --check passes. Composer update currently fails as expected because guzzlehttp/guzzle 8.0.x-dev still requires guzzlehttp/psr7 ^2.10, which conflicts with the root ^3.0@dev constraint.