### PR TITLE
Parse Host header ports in received requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.0.0 - Upcoming
+
+- Dropped support for PHP 7.2 and 7.3
+- Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+- Parse ports from Host headers when reconstructing received requests
+
 ## 0.3.2
 
 - Start the node.js server without shell backgrounding

--- a/src/Server.php
+++ b/src/Server.php
@@ -142,12 +142,19 @@ class Server
                     $message['body'],
                     $message['version']
                 );
+                $uri = $response->getUri()->withScheme('http');
+                $host = $response->getHeaderLine('host');
+                if ($host !== '') {
+                    $parts = \parse_url('http://'.$host);
+                    if (isset($parts['host'])) {
+                        $uri = $uri->withHost($parts['host']);
+                    }
+                    if (isset($parts['port'])) {
+                        $uri = $uri->withPort($parts['port']);
+                    }
+                }
 
-                return $response->withUri(
-                    $response->getUri()
-                        ->withScheme('http')
-                        ->withHost($response->getHeaderLine('host'))
-                );
+                return $response->withUri($uri);
             },
             $data
         );


### PR DESCRIPTION
This splits the received Host header into host and port before applying it to the reconstructed PSR-7 request URI. PSR-7 3.x rejects hosts that include a port, so values like `127.0.0.1:8126` need to call `withHost('127.0.0.1')` and `withPort(8126)` separately.
