### PR TITLE
Fix single response enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Dropped support for PHP 7.2 and 7.3
 - Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
 - Parse ports from Host headers when reconstructing received requests
+- Fixed `Server::enqueue()` to accept a single PSR-7 response as documented
 
 ## 0.3.2
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -62,6 +62,10 @@ class Server
      */
     public static function enqueue($responses)
     {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
         $data = [];
         foreach ((array) $responses as $response) {
             if (!$response instanceof ResponseInterface) {


### PR DESCRIPTION
Fix Server::enqueue() to accept a single PSR-7 response as documented.
