### PR TITLE
Make server controller non-instantiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
 - Parse ports from Host headers when reconstructing received requests
 - Fixed `Server::enqueue()` to accept a single PSR-7 response as documented
+- Made `Server` final and non-instantiable
 
 ## 0.3.2
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
  * number of HTTP request response transactions to test the actual sending of
  * requests over the wire without having to leave an internal network.
  */
-class Server
+final class Server
 {
     /**
      * @var Client|null
@@ -38,6 +38,10 @@ class Server
     private static $started = false;
     public static $url = 'http://127.0.0.1:8126/';
     public static $port = 8126;
+
+    private function __construct()
+    {
+    }
 
     /**
      * Flush the received requests from the server


### PR DESCRIPTION
This declares the test server controller final and makes it non-instantiable. The class is used through its static control methods and static configuration properties.