### PR TITLE
Add server return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Dropped support for PHP 7.2 and 7.3
 - Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
+- Added native return types to `Server` control methods
 - Parse ports from Host headers when reconstructing received requests
 - Fixed `Server::enqueue()` to accept a single PSR-7 response as documented
 - Made `Server` final and non-instantiable

--- a/src/Server.php
+++ b/src/Server.php
@@ -48,7 +48,7 @@ final class Server
      *
      * @throws \RuntimeException
      */
-    public static function flush()
+    public static function flush(): ResponseInterface
     {
         return self::getClient()->request('DELETE', 'guzzle-server/requests');
     }
@@ -64,7 +64,7 @@ final class Server
      *
      * @throws InvalidArgumentException
      */
-    public static function enqueue($responses)
+    public static function enqueue($responses): void
     {
         if ($responses instanceof ResponseInterface) {
             $responses = [$responses];
@@ -102,7 +102,7 @@ final class Server
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public static function enqueueRaw($statusCode, $reasonPhrase, $headers, $body)
+    public static function enqueueRaw($statusCode, $reasonPhrase, $headers, $body): void
     {
         $data = [
             [
@@ -126,7 +126,7 @@ final class Server
      * @throws InvalidArgumentException
      * @throws \RuntimeException
      */
-    public static function received()
+    public static function received(): array
     {
         if (!self::$started) {
             return [];
@@ -196,7 +196,7 @@ final class Server
     /**
      * Stop running the node.js server
      */
-    public static function stop()
+    public static function stop(): void
     {
         try {
             if (self::$started) {
@@ -208,7 +208,7 @@ final class Server
         }
     }
 
-    public static function wait($maxTries = 5)
+    public static function wait($maxTries = 5): void
     {
         $tries = 0;
         while (!self::isListening() && ++$tries < $maxTries) {
@@ -220,7 +220,7 @@ final class Server
         }
     }
 
-    public static function start()
+    public static function start(): void
     {
         if (self::$started) {
             return;


### PR DESCRIPTION
This adds PHP 7.4-compatible native return types to the server control methods and records the typing improvement in the changelog.