### PR TITLE
Add native property types

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -27,9 +27,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class Server
 {
-    /**
-     * @var Client|null
-     */
     private static ?Client $client = null;
     /**
      * @var resource|null

--- a/src/Server.php
+++ b/src/Server.php
@@ -30,12 +30,12 @@ final class Server
     /**
      * @var Client|null
      */
-    private static $client;
+    private static ?Client $client = null;
     /**
      * @var resource|null
      */
     private static $process;
-    private static $started = false;
+    private static bool $started = false;
     public static $url = 'http://127.0.0.1:8126/';
     public static $port = 8126;
 


### PR DESCRIPTION
Adds PHP 7.4-compatible native property types to the private server client and started-state properties while leaving the process resource and public server configuration properties untyped.