### PR TITLE
Add server parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Dropped support for PHP 7.2 and 7.3
 - Switched from Guzzle 7.x to 8.x and from Guzzle PSR-7 2.x to 3.x
 - Added native return types to `Server` control methods
+- Added native parameter types to `Server` utility methods
 - Parse ports from Host headers when reconstructing received requests
 - Fixed `Server::enqueue()` to accept a single PSR-7 response as documented
 - Made `Server` final and non-instantiable

--- a/src/Server.php
+++ b/src/Server.php
@@ -72,7 +72,7 @@ final class Server
             if (!$response instanceof ResponseInterface) {
                 throw new InvalidArgumentException('Invalid response given.');
             }
-            $headers = \array_map(static function ($h) {
+            $headers = \array_map(static function (array $h): string {
                 return \implode(' ,', $h);
             }, $response->getHeaders());
 
@@ -99,7 +99,7 @@ final class Server
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public static function enqueueRaw($statusCode, $reasonPhrase, $headers, $body): void
+    public static function enqueueRaw($statusCode, string $reasonPhrase, array $headers, ?string $body): void
     {
         $data = [
             [
@@ -205,7 +205,7 @@ final class Server
         }
     }
 
-    public static function wait($maxTries = 5): void
+    public static function wait(int $maxTries = 5): void
     {
         $tries = 0;
         while (!self::isListening() && ++$tries < $maxTries) {


### PR DESCRIPTION
This adds PHP 7.4-compatible native parameter types to test server utility methods.