### PR TITLE
Type server public statics

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -33,8 +33,8 @@ final class Server
      */
     private static $process;
     private static bool $started = false;
-    public static $url = 'http://127.0.0.1:8126/';
-    public static $port = 8126;
+    public static string $url = 'http://127.0.0.1:8126/';
+    public static int $port = 8126;
 
     private function __construct()
     {


### PR DESCRIPTION
This adds native scalar types to the test server URL and port static properties while leaving resource-backed process state untyped.