### PR TITLE
Parse host header ports in received requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.3 - Upcoming
+
+- Parse ports from Host headers when reconstructing received requests
+
 ## 0.3.2
 
 - Start the node.js server without shell backgrounding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.3.3 - Upcoming
+## 0.4.0 - Upcoming
 
 - Parse ports from Host headers when reconstructing received requests
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -142,12 +142,19 @@ class Server
                     $message['body'],
                     $message['version']
                 );
+                $uri = $response->getUri()->withScheme('http');
+                $host = $response->getHeaderLine('host');
+                if ($host !== '') {
+                    $parts = \parse_url('http://'.$host);
+                    if (isset($parts['host'])) {
+                        $uri = $uri->withHost($parts['host']);
+                    }
+                    if (isset($parts['port'])) {
+                        $uri = $uri->withPort($parts['port']);
+                    }
+                }
 
-                return $response->withUri(
-                    $response->getUri()
-                        ->withScheme('http')
-                        ->withHost($response->getHeaderLine('host'))
-                );
+                return $response->withUri($uri);
             },
             $data
         );


### PR DESCRIPTION
This preserves Host header ports when reconstructing received request URIs on the 0.4 line.