### PR TITLE
Reject native PHP serialization of Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Dropped support for PHP 7.2 and 7.3
 - Require `guzzlehttp/guzzle` ^8.0 and `guzzlehttp/psr7` ^3.0
+- Reject native PHP serialization of `Server`
 - Made `Server` final and non-instantiable
 - Added native return types to `Server` control methods
 - Added native parameter types to `Server` utility methods

--- a/src/Server.php
+++ b/src/Server.php
@@ -40,6 +40,16 @@ final class Server
     {
     }
 
+    public function __serialize(): array
+    {
+        throw new \LogicException(self::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(self::class.' should never be unserialized');
+    }
+
     /**
      * Flush the received requests from the server
      *


### PR DESCRIPTION
This rejects native PHP serialization for Server and documents the new behavior.