### PR TITLE
Disable proxying on the local control client and guard the empty queue

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -300,6 +300,7 @@ final class Server
         if (null === self::$client) {
             self::$client = new Client([
                 'base_uri' => self::$url,
+                'proxy' => '',
                 'sync' => true,
             ]);
         }

--- a/src/server.js
+++ b/src/server.js
@@ -250,6 +250,11 @@ var GuzzleServer = function(port, log) {
       }
       that.requests.push(request);
       var response = that.responses.shift();
+      if (!response) {
+        res.writeHead(500);
+        res.end('No responses in queue');
+        return;
+      }
       res.writeHead(response.status, response.reason, response.headers);
       res.end(response.body);
     }


### PR DESCRIPTION
The control client that drives the test server is built with no proxy settings, so it honors an ambient `http_proxy` like any Guzzle client. When a consumer test sets `http_proxy` — especially to the server's own URL — the control client's flush and enqueue requests get routed through that proxy in absolute form, which the node server mishandles: an absolute URL containing `/guzzle-server` matches neither the control-path branch nor the empty-queue branch, falls through to the response path, and dereferences an empty queue with an uncaught TypeError that crashes the process and takes down every later test. This pins the control client to no proxy so it always talks directly to the local fixture, and guards the response path to return a 500 instead of crashing on an empty queue. It carries no CHANGELOG entry: the identical fix on the 0.5 companion holds the entry, which flows up on the 0.5 to 1.0 merge.
