### PR TITLE
Disable proxying on the local control client and guard the empty queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.5.1 - Upcoming
+
+- Disable proxying on the control client so an ambient `http_proxy` cannot misroute it
+- Return a 500 instead of crashing when the response queue is empty
+
 ## 0.5.0 - 2026-06-02
 
 - Require `guzzlehttp/guzzle` ^7.11 and `guzzlehttp/psr7` ^2.11

--- a/src/Server.php
+++ b/src/Server.php
@@ -287,6 +287,7 @@ class Server
         if (null === self::$client) {
             self::$client = new Client([
                 'base_uri' => self::$url,
+                'proxy' => '',
                 'sync' => true,
             ]);
         }

--- a/src/server.js
+++ b/src/server.js
@@ -234,6 +234,11 @@ var GuzzleServer = function(port, log) {
       }
       that.requests.push(request);
       var response = that.responses.shift();
+      if (!response) {
+        res.writeHead(500);
+        res.end('No responses in queue');
+        return;
+      }
       res.writeHead(response.status, response.reason, response.headers);
       res.end(response.body);
     }


### PR DESCRIPTION
The control client that drives the test server is built with no proxy settings, so it honors an ambient `http_proxy` like any Guzzle client. When a consumer test sets `http_proxy` — especially to the server's own URL — the control client's flush and enqueue requests get routed through that proxy in absolute form, which the node server mishandles: an absolute URL containing `/guzzle-server` matches neither the control-path branch nor the empty-queue branch, falls through to the response path, and dereferences an empty queue with an uncaught TypeError that crashes the process and takes down every later test. This pins the control client to no proxy so it always talks directly to the local fixture, and guards the response path to return a 500 instead of crashing on an empty queue. This is the 0.5 companion to the identical fix on the 1.0 line.
