### PR TITLE
Add raw response mode to test server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added native return types to `Server` control methods
 - Added native parameter types to `Server` utility methods
 - Added a `guzzle-server/read-timeout-gzip` endpoint that stalls mid-body
+- Added `Server::enqueueRawBytes()` to queue verbatim-byte responses that bypass Node's HTTP handling
 
 ## 0.6.0 - 2026-06-23
 

--- a/docs/test-server-usage.md
+++ b/docs/test-server-usage.md
@@ -67,10 +67,16 @@ Server::enqueue([
 ]);
 ```
 
-Use `Server::enqueueRaw()` when a PSR-7 response is not suitable, such as when you need exact headers or a raw reason phrase.
+Use `Server::enqueueRaw()` when a PSR-7 response is not suitable, such as when you need exact headers or a raw reason phrase. The response is still written through Node's HTTP response handling.
 
 ```php
 Server::enqueueRaw(200, 'OK', ['X-Test' => 'raw'], 'response body');
+```
+
+Use `Server::enqueueRawBytes()` when a test needs a byte-exact response that bypasses Node's HTTP response handling entirely. The bytes are written straight to the client socket and the connection is closed after they are written. This is useful for emulating misbehaving servers that send protocol-invalid bytes, such as a body after a HEAD response.
+
+```php
+Server::enqueueRawBytes("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello");
 ```
 
 ## Inspecting Requests

--- a/src/Server.php
+++ b/src/Server.php
@@ -100,7 +100,9 @@ final class Server
     }
 
     /**
-     * Queue a single raw response manually, to handle cases where PSR7 response is not suitable.
+     * Queue a single response manually, to handle cases where PSR7 response is not suitable.
+     *
+     * This response is still written through Node's HTTP response handling.
      *
      * @param int|string  $statusCode   Status code for the response, e.g. 200
      * @param string      $reasonPhrase Status reason response e.g "OK"
@@ -122,6 +124,27 @@ final class Server
 
         self::getClient()->request('PUT', 'guzzle-server/responses', [
             'json' => $data,
+        ]);
+    }
+
+    /**
+     * Queue a single response as verbatim bytes written straight to the
+     * client socket, bypassing Node's HTTP response handling entirely. The
+     * connection is closed after the bytes are written. Use this to emulate
+     * misbehaving servers, e.g. one that sends a body in response to a HEAD
+     * request.
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public static function enqueueRawBytes(string $bytes): void
+    {
+        self::getClient()->request('PUT', 'guzzle-server/responses', [
+            'json' => [
+                [
+                    'raw' => true,
+                    'body' => \base64_encode($bytes),
+                ],
+            ],
         ]);
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -225,7 +225,7 @@ var GuzzleServer = function(port, log) {
         }
         that.responses = responses;
         for (var i = 0; i < that.responses.length; i++) {
-          if (that.responses[i].body) {
+          if (Object.prototype.hasOwnProperty.call(that.responses[i], 'body') && that.responses[i].body !== null) {
             that.responses[i].body = Buffer.from(that.responses[i].body, 'base64');
           }
         }
@@ -253,6 +253,13 @@ var GuzzleServer = function(port, log) {
       if (!response) {
         res.writeHead(500);
         res.end('No responses in queue');
+        return;
+      }
+      if (response.raw === true) {
+        if (that.log) {
+          console.log('Returning raw response from queue');
+        }
+        res.socket.end(response.body);
         return;
       }
       res.writeHead(response.status, response.reason, response.headers);


### PR DESCRIPTION
This adds a byte-exact raw response mode for queued test-server responses so downstream tests can emulate misbehaving servers that Node HTTP response handling would otherwise normalize. The new Server::enqueueRawBytes() API queues verbatim bytes for direct socket writes, keeps request recording intact, and documents how it differs from the existing normalized Server::enqueueRaw() helper.