### PR TITLE
Sync Server PHPDoc with docs and wrap to 80 columns

### DIFF
--- a/docs/test-server-usage.md
+++ b/docs/test-server-usage.md
@@ -1,10 +1,20 @@
 # Test Server Usage
 
-Use the test server for tests that need a local HTTP endpoint with queued responses and recorded requests. The server is controlled from PHP, but the HTTP server process itself runs on Node.js. This guide covers the PHP control API and request/response behavior; setup and version requirements are documented in the project README.
+Use the test server for tests that need a local HTTP endpoint with queued
+responses and recorded requests. The server is controlled from PHP, but the HTTP
+server process itself runs on Node.js. This guide covers the PHP control API and
+request/response behavior; setup and version requirements are documented in the
+project README.
 
 ## When to Use the Test Server
 
-You almost never need this package when testing normal Guzzle clients. Prefer Guzzle's [Mock Handler](https://github.com/guzzle/guzzle/blob/8.0/docs/testing-guzzle-clients.md#mock-handler) and [History Middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/testing-guzzle-clients.md#history-middleware) for most client tests. Use the test server when implementing HTTP handlers or when a test must exercise an actual local HTTP server.
+You almost never need this package when testing normal Guzzle clients. Prefer
+Guzzle's
+[Mock Handler](https://github.com/guzzle/guzzle/blob/8.0/docs/testing-guzzle-clients.md#mock-handler)
+and
+[History Middleware](https://github.com/guzzle/guzzle/blob/8.0/docs/testing-guzzle-clients.md#history-middleware)
+for most client tests. Use the test server when implementing HTTP handlers or
+when a test must exercise an actual local HTTP server.
 
 ## Basic Usage
 
@@ -35,17 +45,30 @@ echo $requests[0]->getMethod();
 
 ## Lifecycle
 
-`GuzzleHttp\Server\Server` provides a static interface to the test server. Call `Server::start()` before sending requests to `Server::$url`. `Server::start()` starts the Node.js process when needed and waits until it can receive requests before returning.
+`GuzzleHttp\Server\Server` provides a static interface to the test server. Call
+`Server::start()` before sending requests to `Server::$url`. `Server::start()`
+starts the Node.js process when needed and waits until it can receive requests
+before returning.
 
-`Server::start()` and `Server::stop()` are idempotent. Calling `Server::start()` while the server is already started returns immediately, and calling `Server::stop()` when it is not started is safe.
+`Server::start()` and `Server::stop()` are idempotent. Calling `Server::start()`
+while the server is already started returns immediately, and calling
+`Server::stop()` when it is not started is safe.
 
-Operations that use the control API, such as `Server::enqueue()` and `Server::flush()`, create the internal control client and require the server to be reachable. They do not universally start the server for you. `Server::received()` is the exception: before the server has been started, it returns an empty array.
+Operations that use the control API, such as `Server::enqueue()` and
+`Server::flush()`, create the internal control client and require the server to
+be reachable. They do not universally start the server for you.
+`Server::received()` is the exception: before the server has been started, it
+returns an empty array.
 
-Registering `Server::stop()` as a shutdown function helps avoid leaving the local server running after a failing test.
+Registering `Server::stop()` as a shutdown function helps avoid leaving the
+local server running after a failing test.
 
 ## Configuration
 
-By default, the test server listens on `127.0.0.1:8126` and `Server::$url` is `http://127.0.0.1:8126/`. Set `Server::$port` and `Server::$url` before the first server operation or internal control client use if a test needs a different port.
+By default, the test server listens on `127.0.0.1:8126` and `Server::$url` is
+`http://127.0.0.1:8126/`. Set `Server::$port` and `Server::$url` before the
+first server operation or internal control client use if a test needs a
+different port.
 
 ```php
 Server::$port = 8127;
@@ -56,9 +79,14 @@ Server::start();
 
 ## Queuing Responses
 
-Use `Server::enqueue()` to define the responses the server should return. It accepts a `Psr\Http\Message\ResponseInterface` or an array of `ResponseInterface` objects.
+Use `Server::enqueue()` to define the responses the server should return. It
+accepts a `Psr\Http\Message\ResponseInterface` or an array of
+`ResponseInterface` objects.
 
-When responses are queued, they replace any previously queued responses. As the server receives requests, queued responses are returned in FIFO order. When the queue is empty, the server returns a 500 response and does not record the request.
+When responses are queued, they replace any previously queued responses. As the
+server receives requests, queued responses are returned in FIFO order. When the
+queue is empty, the server returns a 500 response and does not record the
+request.
 
 ```php
 Server::enqueue([
@@ -67,13 +95,19 @@ Server::enqueue([
 ]);
 ```
 
-Use `Server::enqueueRaw()` when a PSR-7 response is not suitable, such as when you need exact headers or a raw reason phrase. The response is still written through Node's HTTP response handling.
+Use `Server::enqueueRaw()` when a PSR-7 response is not suitable, such as when
+you need exact headers or a raw reason phrase. The response is still written
+through Node's HTTP response handling.
 
 ```php
 Server::enqueueRaw(200, 'OK', ['X-Test' => 'raw'], 'response body');
 ```
 
-Use `Server::enqueueRawBytes()` when a test needs a byte-exact response that bypasses Node's HTTP response handling entirely. The bytes are written straight to the client socket and the connection is closed after they are written. This is useful for emulating misbehaving servers that send protocol-invalid bytes, such as a body after a HEAD response.
+Use `Server::enqueueRawBytes()` to queue a single response as verbatim bytes
+written straight to the client socket, bypassing Node's HTTP response handling
+entirely. The connection is closed after the bytes are written. Use this to
+emulate misbehaving servers that send protocol-invalid bytes, such as one that
+sends a body in response to a HEAD request.
 
 ```php
 Server::enqueueRawBytes("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello");
@@ -81,7 +115,8 @@ Server::enqueueRawBytes("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello");
 
 ## Inspecting Requests
 
-Use `Server::received()` to retrieve the requests sent to the server. Before the server has been started, it returns an empty array.
+Use `Server::received()` to retrieve the requests sent to the server. Before the
+server has been started, it returns an empty array.
 
 ```php
 $requests = Server::received();
@@ -92,7 +127,8 @@ echo $requests[0]->getBody();
 
 ## Clearing Received Requests
 
-Use `Server::flush()` to clear the list of received requests. It does not change the queued responses.
+Use `Server::flush()` to clear the list of received requests. It does not change
+the queued responses.
 
 ```php
 Server::flush();

--- a/src/Server.php
+++ b/src/Server.php
@@ -51,7 +51,8 @@ final class Server
     }
 
     /**
-     * Flush the received requests from the server
+     * Clear the list of received requests. It does not change the queued
+     * responses.
      *
      * @throws \RuntimeException
      */
@@ -63,8 +64,10 @@ final class Server
     /**
      * Queue an array of responses or a single response on the server.
      *
-     * Any currently queued responses will be overwritten.  Subsequent requests
-     * on the server will return queued responses in FIFO order.
+     * When responses are queued, they replace any previously queued responses.
+     * As the server receives requests, queued responses are returned in FIFO
+     * order. When the queue is empty, the server returns a 500 response and
+     * does not record the request.
      *
      * @param array|ResponseInterface $responses A single or array of Responses
      *                                           to queue.
@@ -100,9 +103,10 @@ final class Server
     }
 
     /**
-     * Queue a single response manually, to handle cases where PSR7 response is not suitable.
+     * Queue a single response manually, for cases where a PSR-7 response is not
+     * suitable, such as when you need exact headers or a raw reason phrase.
      *
-     * This response is still written through Node's HTTP response handling.
+     * The response is still written through Node's HTTP response handling.
      *
      * @param int|string  $statusCode   Status code for the response, e.g. 200
      * @param string      $reasonPhrase Status reason response e.g "OK"
@@ -128,11 +132,11 @@ final class Server
     }
 
     /**
-     * Queue a single response as verbatim bytes written straight to the
-     * client socket, bypassing Node's HTTP response handling entirely. The
-     * connection is closed after the bytes are written. Use this to emulate
-     * misbehaving servers, e.g. one that sends a body in response to a HEAD
-     * request.
+     * Queue a single response as verbatim bytes written straight to the client
+     * socket, bypassing Node's HTTP response handling entirely. The connection
+     * is closed after the bytes are written. Use this to emulate misbehaving
+     * servers that send protocol-invalid bytes, such as one that sends a body
+     * in response to a HEAD request.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
@@ -149,7 +153,9 @@ final class Server
     }
 
     /**
-     * Get all of the received requests
+     * Get all of the received requests.
+     *
+     * Before the server has been started, it returns an empty array.
      *
      * @return RequestInterface[]
      *


### PR DESCRIPTION
Aligns the PHPDoc on the `Server` methods with the prose in `docs/test-server-usage.md` and wraps both to a greedy 80 columns. The descriptions for `flush`, `enqueue`, `enqueueRaw`, `enqueueRawBytes`, and `received` are made consistent between the two and corrected against the server's actual behavior, such as an empty response queue returning a 500 without recording the request and `received()` returning an empty array before the server has started. Only descriptions and line breaks change; signatures, tags, and behavior are untouched.