### PR TITLE
Add drip-timeout endpoints for stream handler timeout tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Added native parameter types to `Server` utility methods
 - Added native string and int types to the public `Server::$url` and `Server::$port` configuration properties
 - Added a `guzzle-server/read-timeout-gzip` endpoint that stalls mid-body
+- Added `guzzle-server/drip-timeout` and `guzzle-server/drip-timeout-gzip` endpoints that drip the body every 100ms
+- Added a `guzzle-server/drip-timeout-headers` endpoint that drips the header block every 100ms
 - Added `Server::enqueueRawBytes()` to queue verbatim-byte responses that bypass Node's HTTP handling
 - Inline Digest auth so secure endpoints avoid optional `http-auth` and no-qop is deterministic
 

--- a/src/server.js
+++ b/src/server.js
@@ -276,6 +276,69 @@ var GuzzleServer = function(port, log) {
         setTimeout(function () {
           res.end(gzipped.slice(half));
         }, 60*1000);
+      } else if (req.url == '/guzzle-server/drip-timeout') {
+        if (that.log) {
+          console.log('Dripping response body');
+        }
+        res.writeHead(200, 'OK');
+        // Send one body byte every 100ms so no single read stalls, while the
+        // whole body takes ~2 seconds to arrive.
+        var dripped = 0;
+        var dripInterval = setInterval(function () {
+          res.write('.');
+          if (++dripped >= 20) {
+            clearInterval(dripInterval);
+            res.end();
+          }
+        }, 100);
+        req.on('close', function () {
+          clearInterval(dripInterval);
+        });
+      } else if (req.url == '/guzzle-server/drip-timeout-gzip') {
+        if (that.log) {
+          console.log('Dripping response body (gzip)');
+        }
+        var gzippedDrip = zlib.gzipSync(
+          Buffer.from('hi there ... this gzip body arrives slowly\n'.repeat(64))
+        );
+        var pieceLength = Math.ceil(gzippedDrip.length / 20);
+        var offset = 0;
+        res.writeHead(200, 'OK', { 'Content-Encoding': 'gzip' });
+        // Send a valid gzip slice every 100ms so no single read stalls, while
+        // the whole body takes ~2 seconds to arrive.
+        var gzipDripInterval = setInterval(function () {
+          res.write(gzippedDrip.slice(offset, offset + pieceLength));
+          offset += pieceLength;
+          if (offset >= gzippedDrip.length) {
+            clearInterval(gzipDripInterval);
+            res.end();
+          }
+        }, 100);
+        req.on('close', function () {
+          clearInterval(gzipDripInterval);
+        });
+      } else if (req.url == '/guzzle-server/drip-timeout-headers') {
+        if (that.log) {
+          console.log('Dripping response headers');
+        }
+        // Write the header block to the raw socket so the header phase itself
+        // arrives slowly (~0.8 seconds) without any single read stalling.
+        res.socket.write('HTTP/1.1 200 OK\r\n');
+        var headerCount = 0;
+        var headerInterval = setInterval(function () {
+          if (res.socket.destroyed) {
+            clearInterval(headerInterval);
+            return;
+          }
+          res.socket.write('X-Drip-' + headerCount + ': ' + headerCount + '\r\n');
+          if (++headerCount >= 8) {
+            clearInterval(headerInterval);
+            res.socket.end('Content-Length: 2\r\nConnection: close\r\n\r\nok');
+          }
+        }, 100);
+        req.on('close', function () {
+          clearInterval(headerInterval);
+        });
       }
     } else if (req.method == 'PUT' && req.url == '/guzzle-server/responses') {
       if (that.log) {


### PR DESCRIPTION
Guzzle 8's stream handler is gaining enforcement of the `timeout` request option as a total transfer deadline, and its tests need a server that keeps a connection active without ever leaving a single read idle. This adds three control endpoints: `guzzle-server/drip-timeout` sends one body byte every 100ms for two seconds, `guzzle-server/drip-timeout-gzip` does the same with a gzip-encoded body so the deadline can be exercised through response decoding, and `guzzle-server/drip-timeout-headers` writes the header block itself to the raw socket in 100ms pieces so a header phase can outlive a deadline without any single read stalling. The drip intervals are cleared when the client disconnects so an aborted request does not leave timers writing to a dead socket.