### PR TITLE
Add a stall-brief endpoint for ini-independent timeout tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added a `guzzle-server/read-timeout-gzip` endpoint that stalls mid-body
 - Added `guzzle-server/drip-timeout` and `guzzle-server/drip-timeout-gzip` endpoints that drip the body every 100ms
 - Added a `guzzle-server/drip-timeout-headers` endpoint that drips the header block every 100ms
+- Added a `guzzle-server/stall-brief` endpoint that stalls mid-body for 1.5s, then completes
 - Added `Server::enqueueRawBytes()` to queue verbatim-byte responses that bypass Node's HTTP handling
 - Inline Digest auth so secure endpoints avoid optional `http-auth` and no-qop is deterministic
 

--- a/src/server.js
+++ b/src/server.js
@@ -340,6 +340,17 @@ var GuzzleServer = function(port, log) {
             res.socket.end('Content-Length: 2\r\nConnection: close\r\n\r\nok');
           }
         }, 100);
+      } else if (req.url == '/guzzle-server/stall-brief') {
+        if (that.log) {
+          console.log('Stalling briefly');
+        }
+        // Stall mid-body for longer than a small socket timeout, then finish,
+        // so a completed response can be observed without a long wait.
+        res.writeHead(200, 'OK');
+        res.write('partial-');
+        setTimeout(function () {
+          res.end('rest');
+        }, 1500);
       }
     } else if (req.method == 'PUT' && req.url == '/guzzle-server/responses') {
       if (that.log) {


### PR DESCRIPTION
Guzzle 8's stream handler is dropping its fallback to the `default_socket_timeout` ini setting, and proving that requires a response that stalls for longer than a small ini value but still completes quickly. The existing stall endpoints pause for 60 seconds, which is unusable in a test that must observe a successful completion. This adds `guzzle-server/stall-brief`, which sends the response headers and a partial body immediately, pauses for 1.5 seconds, and then completes the body, so a test can set a one-second socket timeout and assert that the request still succeeds.