### PR TITLE
Document the ASCII case folding requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@
   `\is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF')` otherwise.
 - This package has no test suite of its own; it is exercised by Guzzle's HTTP
   handler integration tests, which use it as a development dependency.
+- Never call `strtolower()`, `strtoupper()`, `strcasecmp()`, `stripos()`, or
+  other locale-sensitive case functions; use the locale-independent
+  `GuzzleHttp\Psr7\Utils::asciiToLower()`, `asciiToUpper()`,
+  `caselessEquals()`, and `caselessContains()` helpers instead.
 - Changes in behavior need a `CHANGELOG.md` entry in the unreleased section of
   the target branch and an `UPGRADING.md` note when the behavior differs between
   major versions.


### PR DESCRIPTION
PHP's case-conversion functions honor `LC_CTYPE` before PHP 8.2, and the ecosystem-wide sweep converting every call site to locale-independent ASCII folds (guzzle/psr7#851 and siblings) added a corresponding AGENTS.md rule to the packages it touched. This adds the same rule here preventively so future code follows it, mandating the `GuzzleHttp\Psr7\Utils` helpers this package can already reach through its psr7 dependency.