### PR TITLE
Flush headers eagerly in the drip body endpoints

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -281,6 +281,9 @@ var GuzzleServer = function(port, log) {
           console.log('Dripping response body');
         }
         res.writeHead(200, 'OK');
+        // Flush the headers now; Node would otherwise hold them until the
+        // first timer tick, risking the client's header-phase timeout.
+        res.flushHeaders();
         // Send one body byte every 100ms so no single read stalls, while the
         // whole body takes ~2 seconds to arrive. The disconnect check runs
         // inside the tick because the request 'close' event fires when the
@@ -307,6 +310,9 @@ var GuzzleServer = function(port, log) {
         var pieceLength = Math.ceil(gzippedDrip.length / 20);
         var offset = 0;
         res.writeHead(200, 'OK', { 'Content-Encoding': 'gzip' });
+        // Flush the headers now; Node would otherwise hold them until the
+        // first timer tick, risking the client's header-phase timeout.
+        res.flushHeaders();
         // Send a valid gzip slice every 100ms so no single read stalls, while
         // the whole body takes ~2 seconds to arrive.
         var gzipDripInterval = setInterval(function () {


### PR DESCRIPTION
Guzzle's Windows CI intermittently fails the stream handler timeout tests that hit the drip-timeout and drip-timeout-gzip endpoints, with fopen reporting that the HTTP request failed rather than the expected mid-body ResponseTimeoutException, as in https://github.com/guzzle/guzzle/actions/runs/29135009903/job/86497509925. Node buffers the header block written by writeHead() until the first body write, and these two endpoints only perform their first write on the first 100ms timer tick, so on a loaded runner a delayed tick can push the first packet on the wire past the client's one second header-phase timeout and the request fails before the body drip is ever observed. Flushing the header block as soon as the request is handled makes the header phase independent of timer scheduling while the body still drips over roughly two seconds, and a stalled machine now only makes the expected body-phase timeout more certain. The other slow endpoints already send their first bytes synchronously, and drip-timeout-headers deliberately keeps its timer-paced header block because slowly arriving headers are the behavior it exists to exercise.