### PR TITLE
Decode requests without Guzzle JSON helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.0 - Upcoming
+
+- Decode received request data without Guzzle's deprecated JSON utility
+
 ## 0.6.0 - 2026-06-23
 
 - Require `guzzlehttp/guzzle` ^7.12.3 and `guzzlehttp/psr7` ^2.12.3

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,7 +5,6 @@ namespace GuzzleHttp\Server;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -127,7 +126,10 @@ class Server
         }
 
         $response = self::getClient()->request('GET', 'guzzle-server/requests');
-        $data = Utils::jsonDecode((string) $response->getBody(), true);
+        $data = \json_decode((string) $response->getBody(), true);
+        if (\JSON_ERROR_NONE !== \json_last_error()) {
+            throw new \RuntimeException('Unable to decode received requests: '.\json_last_error_msg());
+        }
 
         if (!\is_array($data)) {
             throw new \RuntimeException(\sprintf('Expected JSON array of received requests from node.js server; got %s', \get_debug_type($data)));


### PR DESCRIPTION
Guzzle 7.15 deprecates its generic JSON utilities, so test-server should no longer depend on them. This decodes received request data with PHP’s native JSON functions and reports malformed data through test-server’s `RuntimeException` boundary while retaining PHP 7.2.5 support.