### PR TITLE
Add PHP 8.6 to the version guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1 - Upcoming
 
-- Added PHP 8.6 to the supported versions
+- Added support for PHP 8.6
 
 ## 1.0.0 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1 - Upcoming
+
+- Added PHP 8.6 to the supported versions
+
 ## 1.0.0 - 2026-07-20
 
 - Dropped support for PHP 7.2 and 7.3

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The server requires Node.js `^20.19 || ^22.13 || >=24` available as `node`.
 
 | Version | Status       | PHP Version  |
 |---------|--------------|--------------|
-| 1.0     | Latest       | >=7.4,<8.6   |
-| 0.7     | Maintenance  | >=7.2.5,<8.6 |
+| 1.0     | Latest       | >=7.4,<8.7   |
+| 0.7     | Maintenance  | >=7.2.5,<8.7 |
 
 ## Quick Start
 


### PR DESCRIPTION
The test suite passes under PHP 8.6.0beta1 unchanged and this branch has no test workflow to extend, so this records PHP 8.6 in the version guidance.
