### PR TITLE
Document PHP 8.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.1 - Upcoming
 
-- Added PHP 8.6 to the supported versions
+- Add support for PHP 8.6
 
 ## 0.7.0 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.1 - Upcoming
+
+- Added PHP 8.6 to the supported versions
+
 ## 0.7.0 - 2026-07-16
 
 - Require `guzzlehttp/guzzle` ^7.13.3 and `guzzlehttp/psr7` ^2.12.4


### PR DESCRIPTION
The test suite passes under PHP 8.6.0beta1 unchanged and this branch has no test workflow to extend, so this documents PHP 8.6 support.
